### PR TITLE
Changes that were needed for this to run via Docker instead of Postman

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ LABEL CREATEDBY "Matthew Stobbs <matthew.stobbs@ucalgary.ca>"
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG CANDIG_REPO=https://github.com/CanDIG/CanDIGv2.git
-ARG BRANCH=stable
+ARG BRANCH=develop
 ARG YQBINARY=yq_linux_amd64
 ARG YQVERSION=v4.44.1
 
@@ -34,4 +34,7 @@ RUN curl -L https://github.com/mikefarah/yq/releases/download/${YQVERSION}/${YQB
 RUN git clone -b ${BRANCH} --recurse-submodules ${CANDIG_REPO} /candig
 
 WORKDIR /candig
-ENTRYPOINT ["make", "install-all"]
+
+COPY ./install-all.sh /candig/install-all.sh
+
+ENTRYPOINT ["bash", "install-all.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ LABEL CREATEDBY "Matthew Stobbs <matthew.stobbs@ucalgary.ca>"
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG CANDIG_REPO=https://github.com/CanDIG/CanDIGv2.git
-ARG BRANCH=develop
+ARG BRANCH=stable
 ARG YQBINARY=yq_linux_amd64
 ARG YQVERSION=v4.44.1
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 *Replace podman witch docker if using docker*
 
 1. Build the container: `podman build -t candig-build:latest -f Dockerfile .`
-2. Run the built container on the machine you want to deploy candig to: `podman run -it -v /var/run/podman/podman.sock:/var/run/docker.sock:ro,z -v /path/to/environment:/candig/.env:ro candig-build:latest`
+2. Run the built container on the machine you want to deploy candig to: `podman run -it -v /var/run/podman/podman.sock:/var/run/docker.sock:ro,z -v /path/to/environment:/candig/.env:ro -v /candig/tmp:/candig/tmp candig-build:latest`
 3. That's it!
 
 ## Notes about the Dockerfile
@@ -24,3 +24,6 @@
   It defaults to the amd64 binary of version 4.44.1 (latest at the time of writing)
 - The CanDIGv2 repository can be changed by setting the argument `CANDIG_REPO`. defaults to the official repository
 - The branch can be changed by setting the arguement `BRANCH`. defaults to stable
+- Due to how Docker handles volumes, you must also create the `/candig/tmp/` folder on your machine
+- You will need to fill out the LOCAL_IP_ADDR in your `.env` file, as it cannot be automatically found from within Docker
+

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ## Instructions
 
-*Replace podman witch docker if using docker*
+*Replace podman with docker if using docker*
 
 1. Build the container: `podman build -t candig-build:latest -f Dockerfile .`
 2. Run the built container on the machine you want to deploy candig to: `podman run -it -v /var/run/podman/podman.sock:/var/run/docker.sock:ro,z -v /path/to/environment:/candig/.env:ro -v /candig/tmp:/candig/tmp candig-build:latest`

--- a/install-all.sh
+++ b/install-all.sh
@@ -1,4 +1,3 @@
-pwd
 make bin-conda
 source ${HOME}/.bashrc
 make init-conda

--- a/install-all.sh
+++ b/install-all.sh
@@ -1,0 +1,6 @@
+pwd
+make bin-conda
+source ${HOME}/.bashrc
+make init-conda
+conda activate candig
+make build-all


### PR DESCRIPTION
I found that the `make install-all` directive no longer works, so I wrote everything into a separate `.sh` script. This works on my machine, but it does require that you create a `/candig/tmp` folder on your host machine.